### PR TITLE
Update quickstart-github-enterprise.template to GHES 3.8.5

### DIFF
--- a/templates/quickstart-github-enterprise.template
+++ b/templates/quickstart-github-enterprise.template
@@ -94,35 +94,37 @@ Conditions:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      GHE: GitHub Enterprise Server 2.22.0
+      GHE: GitHub Enterprise Server 3.8.5
     ap-northeast-1:
-      GHE: ami-0bc3e78568b25c6e3
+      GHE: ami-012ab4feca5d3ef1e
     ap-northeast-2:
-      GHE: ami-09e8efea045dc4369
+      GHE: ami-0518dd81bc98f7977
+    ap-northeast-3:
+      GHE: ami-0518dd81bc98f7977
     ap-south-1:
-      GHE: ami-0b1c3ca03b76bef07
+      GHE: ami-0236b8ba8751ded3d
     ap-southeast-1:
-      GHE: ami-0769f5f40e341617e
+      GHE: ami-02568b74f24f1224a
     ap-southeast-2:
-      GHE: ami-05cef3e0e447c3538
+      GHE: ami-02170121ccb823cea
     ca-central-1:
-      GHE: ami-0c5f69ba25758a2f9
+      GHE: ami-004f792b02ad40411
     eu-central-1:
-      GHE: ami-033da9cc6d8f244d6
+      GHE: ami-092ea07812f83727c
     eu-west-1:
-      GHE: ami-0b6546c8c336c4b27
+      GHE: ami-001b47277f48b5d64
     eu-west-2:
-      GHE: ami-07ec810305329c668
+      GHE: ami-0fd15952c99ee0c59
     sa-east-1:
-      GHE: ami-069c42c56220d739b
+      GHE: ami-04fab7b0f73f78d1f
     us-east-1:
-      GHE: ami-0375dc11ba4620efd
+      GHE: ami-058eafc7ee2581fb6
     us-east-2:
-      GHE: ami-0bae35016f5a376a6
+      GHE: ami-0bc8e3b94c1153260
     us-west-1:
-      GHE: ami-09c9807903410caac
+      GHE: ami-00f9531493726d577
     us-west-2:
-      GHE: ami-0ab275e35551c741c
+      GHE: ami-06f43a42ec4e01030
 Outputs:
   AvailabilityZone:
     Description: Availability Zone of the newly created EC2 instance


### PR DESCRIPTION
*Description of changes:*

This PR updates the ami's to version 3.8.5

I fetched the AMI's using this quick script:

```
for region in `aws ec2 describe-regions --output text | cut -f4`
do
  echo $region
  aws ec2 describe-images --region $region --owners 895557238572 --query 'sort_by(Images,&Name)[*].{Name:Name,ImageID:ImageId}' --output text | tail -n 3 | sed -n '1p'
done
```
