### PR TITLE
Limit AWS Region to only supported regions that GHES has image deployed

### DIFF
--- a/templates/quickstart-github-enterprise-master.template
+++ b/templates/quickstart-github-enterprise-master.template
@@ -1,27 +1,46 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: '(qs-1nae5pfk9) GitHub Enterprise+VPC Quickstart License: Apache 2.0
   (Please do not remove) May,08,2018'
+Transform: AWS::LanguageExtensions
+Mappings:
+  SupportedRegionMap:
+    ap-northeast-1:
+      GHE: True
+    ap-northeast-2:
+      GHE: True
+    ap-northeast-3:
+      GHE: True
+    ap-south-1:
+      GHE: True
+    ap-southeast-1:
+      GHE: True
+    ap-southeast-2:
+      GHE: True
+    ca-central-1:
+      GHE: True
+    eu-central-1:
+      GHE: True
+    eu-west-1:
+      GHE: True
+    eu-west-2:
+      GHE: True
+    sa-east-1:
+      GHE: True
+    us-east-1:
+      GHE: True
+    us-east-2:
+      GHE: True
+    us-west-1:
+      GHE: True
+    us-west-2:
+      GHE: True
 Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
-  ApNe1Condition: !Equals ["ap-northeast-1", !Ref AWS::Region]
-  ApNe2Condition: !Or [!Equals ["ap-northeast-2", !Ref AWS::Region], Condition: ApNe1Condition]
-  ApS1Condition: !Or [!Equals ["ap-south-1", !Ref AWS::Region], Condition: ApNe2Condition]
-  ApSe1Condition: !Or [!Equals ["ap-southeast-1", !Ref AWS::Region], Condition: ApS1Condition]
-  ApSe2Condition: !Or [!Equals ["ap-southeast-2", !Ref AWS::Region], Condition: ApSe1Condition]
-  CaC1Condition: !Or [!Equals ["ca-central-1", !Ref AWS::Region], Condition: ApSe2Condition]
-  EuC1Condition: !Or [!Equals ["eu-central-1", !Ref AWS::Region], Condition: CaC1Condition]
-  EuN1Condition: !Or [!Equals ["eu-north-1", !Ref AWS::Region], Condition: EuC1Condition]
-  EuW1Condition: !Or [!Equals ["eu-west-1", !Ref AWS::Region], Condition: EuN1Condition]
-  EuW2Condition: !Or [!Equals ["eu-west-2", !Ref AWS::Region], Condition: EuW1Condition]
-  SaE1Condition: !Or [!Equals ["sa-east-1", !Ref AWS::Region], Condition: EuW2Condition]
-  UsE1Condition: !Or [!Equals ["us-east-1", !Ref AWS::Region], Condition: SaE1Condition]
-  UsE2Condition: !Or [!Equals ["us-east-2", !Ref AWS::Region], Condition: UsE1Condition]
-  UsW1Condition: !Or [!Equals ["us-west-1", !Ref AWS::Region], Condition: UsE2Condition]
-  AggregatedRegionCondition: !Or [!Equals ["us-west-2", !Ref AWS::Region], Condition: UsW1Condition]
-  SupportedRegionCondition: !And [Condition: UsingDefaultBucket, Condition: AggregatedRegionCondition]
+  IsNotSupportedRegion: !Equals [ !FindInMap [ SupportedRegionMap, !Ref AWS::Region, GHE, DefaultValue: 'False' ], 'False' ]
+  IsSupportedRegion: !Not [!Condition IsNotSupportedRegion]
 Metadata:
   QuickStartDocumentation:
     EntrypointName: "Launch into a new VPC"
@@ -229,7 +248,7 @@ Parameters:
 Resources:
   GHEStack:
     DependsOn: GHEVPCStack
-    Condition: SupportedRegionCondition
+    Condition: IsSupportedRegion
     Properties:
       Parameters:
         AccessCIDR: !Ref 'AccessCIDR'
@@ -258,7 +277,7 @@ Resources:
             S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
     Type: AWS::CloudFormation::Stack
   GHEVPCStack:
-    Condition: SupportedRegionCondition
+    Condition: IsSupportedRegion
     Properties:
       Parameters:
         KeyPairName: !Ref 'KeyPairName'

--- a/templates/quickstart-github-enterprise-master.template
+++ b/templates/quickstart-github-enterprise-master.template
@@ -6,6 +6,21 @@ Conditions:
     - !Ref 'AWS::Region'
     - us-gov-west-1
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
+  ApNe1Condition: !Equals ["ap-northeast-1", !Ref AWS::Region]
+  ApNe2Condition: !Or [!Equals ["ap-northeast-2", !Ref AWS::Region], Condition: ApNe1Condition]
+  ApS1Condition: !Or [!Equals ["ap-south-1", !Ref AWS::Region], Condition: ApNe2Condition]
+  ApSe1Condition: !Or [!Equals ["ap-southeast-1", !Ref AWS::Region], Condition: ApS1Condition]
+  ApSe2Condition: !Or [!Equals ["ap-southeast-2", !Ref AWS::Region], Condition: ApSe1Condition]
+  CaC1Condition: !Or [!Equals ["ca-central-1", !Ref AWS::Region], Condition: ApSe2Condition]
+  EuC1Condition: !Or [!Equals ["eu-central-1", !Ref AWS::Region], Condition: CaC1Condition]
+  EuN1Condition: !Or [!Equals ["eu-north-1", !Ref AWS::Region], Condition: EuC1Condition]
+  EuW1Condition: !Or [!Equals ["eu-west-1", !Ref AWS::Region], Condition: EuN1Condition]
+  EuW2Condition: !Or [!Equals ["eu-west-2", !Ref AWS::Region], Condition: EuW1Condition]
+  SaE1Condition: !Or [!Equals ["sa-east-1", !Ref AWS::Region], Condition: EuW2Condition]
+  UsE1Condition: !Or [!Equals ["us-east-1", !Ref AWS::Region], Condition: SaE1Condition]
+  UsE2Condition: !Or [!Equals ["us-east-2", !Ref AWS::Region], Condition: UsE1Condition]
+  UsW1Condition: !Or [!Equals ["us-west-1", !Ref AWS::Region], Condition: UsE2Condition]
+  SupportedRegionCondition: !Or [!Equals ["us-west-2", !Ref AWS::Region], Condition: UsW1Condition]
 Metadata:
   QuickStartDocumentation:
     EntrypointName: "Launch into a new VPC"
@@ -213,6 +228,7 @@ Parameters:
 Resources:
   GHEStack:
     DependsOn: GHEVPCStack
+    Condition: SupportedRegionCondition
     Properties:
       Parameters:
         AccessCIDR: !Ref 'AccessCIDR'
@@ -241,6 +257,7 @@ Resources:
             S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
     Type: AWS::CloudFormation::Stack
   GHEVPCStack:
+    Condition: SupportedRegionCondition
     Properties:
       Parameters:
         KeyPairName: !Ref 'KeyPairName'

--- a/templates/quickstart-github-enterprise-master.template
+++ b/templates/quickstart-github-enterprise-master.template
@@ -38,7 +38,6 @@ Metadata:
           default: Server Configuration
         Parameters:
           - InstanceType
-          - AWSRegion
           - KeyPairName
           - VolumeType
           - ProvisionedIops
@@ -60,8 +59,6 @@ Metadata:
         default: Initial Repository
       InstanceType:
         default: Instance Type
-      AWSRegion:
-        default: AWS Region
       KeyPairName:
         default: Key Pair Name
       LicenseLocation:
@@ -127,30 +124,6 @@ Parameters:
       - r3.2xlarge
       - r3.4xlarge
       - r3.8xlarge
-  AWSRegion:
-    AllowedValues:
-      - ap-northeast-1
-      - ap-northeast-2
-      - ap-south-1
-      - ap-southeast-1
-      - ap-southeast-2
-      - ca-central-1
-      - eu-central-1
-      - eu-north-1
-      - eu-west-1
-      - eu-west-2
-      - sa-east-1
-      - us-east-1
-      - us-east-2
-      - us-west-1
-      - us-west-2
-    ConstraintDescription: >-
-      must be one of following supported region ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, 
-      ap-southeast-2, ca-central-1, eu-central-1, eu-north-1, eu-west-1, eu-west-2, sa-east-1, us-east-1, 
-      us-east-2, us-west-1, us-west-2
-    Default: !Ref 'AWS::Region'
-    Description: AWS Region that the Quick Start will fetch template from
-    Type: AWS::Region
     ConstraintDescription: >-
       must be a valid EC2 instance type for GitHub Enterprise: m3.xlarge, m3.2xlarge,
       m4.xlarge, m4.2xlarge, c3.2xlarge, c3.4xlarge, c3.8xlarge, c4.2xlarge, c4.4xlarge,
@@ -264,8 +237,8 @@ Resources:
       TemplateURL:
         !Sub
           - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/quickstart-github-enterprise.template'
-          - S3Region: !If [UsingDefaultBucket, !Ref AWSRegion, !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWSRegion}', !Ref QSS3BucketName]
+          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
     Type: AWS::CloudFormation::Stack
   GHEVPCStack:
     Properties:
@@ -275,6 +248,6 @@ Resources:
       TemplateURL:
         !Sub
           - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/quickstart-github-enterprise-single-az-vpc.template'
-          - S3Region: !If [UsingDefaultBucket, !Ref AWSRegion, !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWSRegion}', !Ref QSS3BucketName]
+          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
     Type: AWS::CloudFormation::Stack

--- a/templates/quickstart-github-enterprise-master.template
+++ b/templates/quickstart-github-enterprise-master.template
@@ -38,6 +38,7 @@ Metadata:
           default: Server Configuration
         Parameters:
           - InstanceType
+          - AWSRegion
           - KeyPairName
           - VolumeType
           - ProvisionedIops
@@ -59,6 +60,8 @@ Metadata:
         default: Initial Repository
       InstanceType:
         default: Instance Type
+      AWSRegion:
+        default: AWS Region
       KeyPairName:
         default: Key Pair Name
       LicenseLocation:
@@ -124,6 +127,30 @@ Parameters:
       - r3.2xlarge
       - r3.4xlarge
       - r3.8xlarge
+  AWSRegion:
+    AllowedValues:
+      - ap-northeast-1
+      - ap-northeast-2
+      - ap-south-1
+      - ap-southeast-1
+      - ap-southeast-2
+      - ca-central-1
+      - eu-central-1
+      - eu-north-1
+      - eu-west-1
+      - eu-west-2
+      - sa-east-1
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - us-west-2
+    ConstraintDescription: >-
+      must be one of following supported region ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, 
+      ap-southeast-2, ca-central-1, eu-central-1, eu-north-1, eu-west-1, eu-west-2, sa-east-1, us-east-1, 
+      us-east-2, us-west-1, us-west-2
+    Default: !Ref 'AWS::Region'
+    Description: AWS Region that the Quick Start will fetch template from
+    Type: AWS::Region
     ConstraintDescription: >-
       must be a valid EC2 instance type for GitHub Enterprise: m3.xlarge, m3.2xlarge,
       m4.xlarge, m4.2xlarge, c3.2xlarge, c3.4xlarge, c3.8xlarge, c4.2xlarge, c4.4xlarge,
@@ -237,8 +264,8 @@ Resources:
       TemplateURL:
         !Sub
           - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/quickstart-github-enterprise.template'
-          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+          - S3Region: !If [UsingDefaultBucket, !Ref AWSRegion, !Ref QSS3BucketRegion]
+            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWSRegion}', !Ref QSS3BucketName]
     Type: AWS::CloudFormation::Stack
   GHEVPCStack:
     Properties:
@@ -248,6 +275,6 @@ Resources:
       TemplateURL:
         !Sub
           - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/quickstart-github-enterprise-single-az-vpc.template'
-          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
-            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+          - S3Region: !If [UsingDefaultBucket, !Ref AWSRegion, !Ref QSS3BucketRegion]
+            S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWSRegion}', !Ref QSS3BucketName]
     Type: AWS::CloudFormation::Stack

--- a/templates/quickstart-github-enterprise-master.template
+++ b/templates/quickstart-github-enterprise-master.template
@@ -20,7 +20,8 @@ Conditions:
   UsE1Condition: !Or [!Equals ["us-east-1", !Ref AWS::Region], Condition: SaE1Condition]
   UsE2Condition: !Or [!Equals ["us-east-2", !Ref AWS::Region], Condition: UsE1Condition]
   UsW1Condition: !Or [!Equals ["us-west-1", !Ref AWS::Region], Condition: UsE2Condition]
-  SupportedRegionCondition: !Or [!Equals ["us-west-2", !Ref AWS::Region], Condition: UsW1Condition]
+  AggregatedRegionCondition: !Or [!Equals ["us-west-2", !Ref AWS::Region], Condition: UsW1Condition]
+  SupportedRegionCondition: !And [Condition: UsingDefaultBucket, Condition: AggregatedRegionCondition]
 Metadata:
   QuickStartDocumentation:
     EntrypointName: "Launch into a new VPC"

--- a/templates/quickstart-github-enterprise-master.template
+++ b/templates/quickstart-github-enterprise-master.template
@@ -40,7 +40,8 @@ Conditions:
     - us-gov-west-1
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   IsNotSupportedRegion: !Equals [ !FindInMap [ SupportedRegionMap, !Ref AWS::Region, GHE, DefaultValue: 'False' ], 'False' ]
-  IsSupportedRegion: !Not [!Condition IsNotSupportedRegion]
+  UnSupportedDeployment: !And [!Condition UsingDefaultBucket, !Condition IsNotSupportedRegion]
+  SupportedDeployment: !Not [!Condition UnSupportedDeployment]
 Metadata:
   QuickStartDocumentation:
     EntrypointName: "Launch into a new VPC"
@@ -114,8 +115,6 @@ Metadata:
         default: Site Admin User Password
       SiteAdminUsername:
         default: Site Admin Username
-      SubnetCIDR:
-        default: Subnet CIDR
       VPCCIDR:
         default: VPC CIDR
       VolumeSize:
@@ -248,7 +247,7 @@ Parameters:
 Resources:
   GHEStack:
     DependsOn: GHEVPCStack
-    Condition: IsSupportedRegion
+    Condition: SupportedDeployment
     Properties:
       Parameters:
         AccessCIDR: !Ref 'AccessCIDR'
@@ -277,7 +276,7 @@ Resources:
             S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
     Type: AWS::CloudFormation::Stack
   GHEVPCStack:
-    Condition: IsSupportedRegion
+    Condition: SupportedDeployment
     Properties:
       Parameters:
         KeyPairName: !Ref 'KeyPairName'


### PR DESCRIPTION
*Issue 26*

*Description of changes:*
This is a fix to limit GHES quickstart deployment to happen only on the region that GHES image / nested stack are supported, and which AWS / Github could have full control of the bucket.

Supported GHES regions are
- ap-northeast-1
- ap-northeast-2
- ap-south-1    
- ap-southeast-1
- ap-southeast-2
- ca-central-1  
- eu-central-1  
- eu-north-1    
- eu-west-1     
- eu-west-2     
- eu-west-3     
- sa-east-1     
- us-east-1     
- us-east-2     
- us-west-1     
- us-west-2     

This limitation is only applied when deploy with a default S3 bucket name (`aws-quickstart`)

*Tests*
- case 1
Tested with a random unsupported region `ap-northeast-3`, the deployment will create no resource and immediately "complete" as condition not satisfied.
<img width="1067" alt="Screenshot 2023-09-19 at 11 42 58 AM" src="https://github.com/aws-quickstart/quickstart-github-enterprise/assets/45571951/3f9c1f6c-dc19-4465-8d70-cbabff54d10b">

- case 2 
Tested with a supported region and deployment is as expected

~~Incomplete: Still need to test with `taskcat`.~~